### PR TITLE
Dropping RestSharp dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Library requires to use at least .NET 8.
 
 **External dependencies**
 
-- [RestSharp](https://github.com/restsharp/RestSharp)
 - [XUnit](https://github.com/xunit/xunit)
 
 # Contributing

--- a/src/VirusTotalCore/BaseEndpoint.cs
+++ b/src/VirusTotalCore/BaseEndpoint.cs
@@ -7,14 +7,20 @@ namespace VirusTotalCore;
 
 public abstract class BaseEndpoint
 {
+    protected readonly HttpClient HttpClient;
     protected readonly RestClient Client;
-    private readonly string _url = "https://www.virustotal.com/api/v3";
+    private readonly string _url = "https://www.virustotal.com/api/v3/";
     private readonly string _apiKey = null!;
 
     public BaseEndpoint(string apiKey, string endpoint)
     {
         _url += endpoint;
         ApiKey = apiKey;
+        HttpClient = new HttpClient
+        {
+            BaseAddress = new Uri(_url),
+        };
+        HttpClient.DefaultRequestHeaders.Add("x-apikey", ApiKey);
         var options = new RestClientOptions(_url);
         Client = new RestClient(options);
         Client.AddDefaultHeader("x-apikey", ApiKey);

--- a/src/VirusTotalCore/BaseEndpoint.cs
+++ b/src/VirusTotalCore/BaseEndpoint.cs
@@ -142,6 +142,34 @@ public abstract class BaseEndpoint
         }
     }
 
+    protected async Task<T> PostAsync<T>(string requestUrl, object value, CancellationToken cancellationToken)
+    {
+        var response = await HttpClient.PostAsJsonAsync(requestUrl, value, cancellationToken);
+        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (response is not { IsSuccessStatusCode: true })
+        {
+            throw HandleError(resultJson);
+        }
+        
+        var resultJsonDocument = JsonDocument.Parse(resultJson);
+        var result = resultJsonDocument.Deserialize<T>(JsonSerializerOptions)!;
+        return result;
+    }
+    
+    protected async Task<T> PostAsync<T>(string requestUrl, string jsonRootName, object value, CancellationToken cancellationToken)
+    {
+        var response = await HttpClient.PostAsJsonAsync(requestUrl, value, cancellationToken);
+        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (response is not { IsSuccessStatusCode: true })
+        {
+            throw HandleError(resultJson);
+        }
+        
+        var resultJsonDocument = JsonDocument.Parse(resultJson);
+        var result = resultJsonDocument.RootElement.GetProperty(jsonRootName).Deserialize<T>(JsonSerializerOptions)!;
+        return result;
+    }
+
     /// <summary>
     /// This endpoint allows to get objects relationship to another objects. 
     /// </summary>

--- a/src/VirusTotalCore/BaseEndpoint.cs
+++ b/src/VirusTotalCore/BaseEndpoint.cs
@@ -96,7 +96,7 @@ public abstract class BaseEndpoint
 
     protected async Task<T> GetAsync<T>(string requestUrl, CancellationToken cancellationToken)
     {
-        var response = await HttpClient.GetAsync(requestUrl, cancellationToken);
+        using var response = await HttpClient.GetAsync(requestUrl, cancellationToken);
         var resultJson = await response.Content.ReadAsStringAsync(cancellationToken);
         if (response is not { IsSuccessStatusCode: true })
         {
@@ -110,7 +110,7 @@ public abstract class BaseEndpoint
 
     protected async Task<T> GetAsync<T>(string requestUrl, string jsonRootName, CancellationToken cancellationToken)
     {
-        var response = await HttpClient.GetAsync(requestUrl, cancellationToken);
+        using var response = await HttpClient.GetAsync(requestUrl, cancellationToken);
         var resultJson = await response.Content.ReadAsStringAsync(cancellationToken);
         if (response is not { IsSuccessStatusCode: true })
         {
@@ -122,6 +122,16 @@ public abstract class BaseEndpoint
         return result;
     }
 
+    protected async Task DeleteAsync(string requestUrl, CancellationToken cancellationToken)
+    {
+        using var response = await HttpClient.DeleteAsync(requestUrl, cancellationToken);
+        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (response is not { IsSuccessStatusCode: true })
+        {
+            throw HandleError(resultJson);
+        }
+    }
+
     protected async Task PostAsync(string requestUrl, object value, CancellationToken cancellationToken)
     {
         var response = await HttpClient.PostAsJsonAsync(requestUrl, value, cancellationToken);
@@ -130,25 +140,6 @@ public abstract class BaseEndpoint
         {
             throw HandleError(resultJson);
         }
-    }
-
-    protected Task<RestResponse> PostFormResponse(RestRequest request, CancellationToken? cancellationToken)
-    {
-        return cancellationToken is not null
-            ? Client.ExecuteAsync(request, cancellationToken.Value)
-            : Client.ExecuteAsync(request);
-    }
-
-    protected Task<RestResponse> DeleteResponse(RestRequest request, CancellationToken? cancellationToken)
-    {
-        if (request.Method is not Method.Delete)
-        {
-            throw new ArgumentException("Request method has to be DELETE!");
-        }
-
-        return cancellationToken is not null
-            ? Client.ExecuteAsync(request, cancellationToken.Value)
-            : Client.ExecuteAsync(request);
     }
 
     /// <summary>

--- a/src/VirusTotalCore/BaseEndpoint.cs
+++ b/src/VirusTotalCore/BaseEndpoint.cs
@@ -24,11 +24,11 @@ public abstract class BaseEndpoint
         HttpClient.DefaultRequestHeaders.Add("x-apikey", ApiKey);
     }
 
-    protected BaseEndpoint(HttpClient customHttpClient, string apiKey, string endpoint)
+    protected BaseEndpoint(IHttpClientFactory customHttpClient, string apiKey, string endpoint)
     {
         CurrentEndpointName = endpoint;
         ApiKey = apiKey;
-        HttpClient = customHttpClient;
+        HttpClient = customHttpClient.CreateClient();
         HttpClient.BaseAddress = new Uri(Url);
         HttpClient.DefaultRequestHeaders.Add("x-apikey", ApiKey);
     }

--- a/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
@@ -88,7 +88,7 @@ public class AddressIpEndpoint(string apiKey) : BaseEndpoint(apiKey, "ip_address
     public async Task AddVote(string ipAddress, VerdictType verdict, CancellationToken? cancellationToken)
     {
         var newVote = new AddVote(verdict);
-        var requestUrl = $"/{ipAddress}/votes";
+        var requestUrl = $"{ipAddress}/votes";
         
         await PostAsync(requestUrl, newVote, cancellationToken ?? new CancellationToken());
     }

--- a/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
@@ -7,8 +7,10 @@ using VirusTotalCore.Models.Votes;
 
 namespace VirusTotalCore.Endpoints;
 
-public class AddressIpEndpoint(string apiKey) : BaseEndpoint(apiKey, "ip_addresses/")
+public class AddressIpEndpoint : BaseEndpoint
 {
+    public AddressIpEndpoint(string apiKey) : base(apiKey, "files/") { }
+    public AddressIpEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
     /// <summary>
     ///     Get report on given ip address
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
@@ -9,8 +9,8 @@ namespace VirusTotalCore.Endpoints;
 
 public class AddressIpEndpoint : BaseEndpoint
 {
-    public AddressIpEndpoint(string apiKey) : base(apiKey, "ip_addresses/") { }
-    public AddressIpEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "ip_addresses/") { }
+    public AddressIpEndpoint(string apiKey) : base(apiKey, "ip_addresses") { }
+    public AddressIpEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "ip_addresses") { }
     /// <summary>
     ///     Get report on given ip address
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
@@ -1,6 +1,3 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using RestSharp;
 using VirusTotalCore.Enums;
 using VirusTotalCore.Exceptions;
 using VirusTotalCore.Models.Analysis;
@@ -21,17 +18,8 @@ public class AddressIpEndpoint(string apiKey) : BaseEndpoint(apiKey, "ip_address
     /// <exception cref="NotFoundException">Given IP address not found.</exception>
     public async Task<AnalysisReport<AddressReportAttributes>> GetReport(string ipAddress, CancellationToken? cancellationToken)
     {
-        var response = await HttpClient.GetAsync(ipAddress, cancellationToken: cancellationToken ?? new CancellationToken());
-        var resultJson = await response.Content.ReadAsStringAsync();
-        if (response is not { IsSuccessStatusCode: true })
-        {
-            throw HandleError(resultJson);
-        }
-
-        var resultJsonDocument = JsonDocument.Parse(resultJson);
-        var result = resultJsonDocument.RootElement.GetProperty("data")
-            .Deserialize<AnalysisReport<AddressReportAttributes>>(JsonSerializerOptions)!;
-        return result;
+        const string rootPropertyName = "data";
+        return await GetAsync<AnalysisReport<AddressReportAttributes>>(ipAddress, rootPropertyName, cancellationToken ?? new CancellationToken());
     }
 
     /// <summary>
@@ -54,16 +42,7 @@ public class AddressIpEndpoint(string apiKey) : BaseEndpoint(apiKey, "ip_address
             requestUrl += $"&cursor={cursor}";
         }
 
-        var response = await HttpClient.GetAsync(requestUrl, cancellationToken ?? new CancellationToken());
-        var resultJson = await response.Content.ReadAsStringAsync();
-        if (response is not { IsSuccessStatusCode: true })
-        {
-            throw HandleError(resultJson);
-        }
-        
-        var resultJsonDocument = JsonDocument.Parse(resultJson);
-        var result = resultJsonDocument.Deserialize<CommentData>(JsonSerializerOptions)!;
-        return result;
+        return await GetAsync<CommentData>(requestUrl, cancellationToken ?? new CancellationToken());
     }
 
     /// <summary>
@@ -81,12 +60,7 @@ public class AddressIpEndpoint(string apiKey) : BaseEndpoint(apiKey, "ip_address
         var newComment = new AddComment(comment);
         var requestUrl = $"{ipAddress}/comments";
 
-        var response = await HttpClient.PostAsJsonAsync(requestUrl, newComment, cancellationToken ?? new CancellationToken());
-        var resultJson = await response.Content.ReadAsStringAsync();
-        if (response is not { IsSuccessStatusCode: true })
-        {
-            throw HandleError(resultJson);
-        }
+        await PostAsync(requestUrl, newComment, cancellationToken ?? new CancellationToken());
     }
 
     /// <summary>
@@ -98,28 +72,8 @@ public class AddressIpEndpoint(string apiKey) : BaseEndpoint(apiKey, "ip_address
     /// <exception cref="NotFoundException">Given IP address not found.</exception>
     public async Task<VoteData> GetVotes(string ipAddress, CancellationToken? cancellationToken)
     {
-        /*var requestUrl = $"/{ipAddress}/votes";
-
-        var request = new RestRequest(requestUrl);
-        var restResponse = await GetResponse(request, cancellationToken);
-
-        if (restResponse is not { IsSuccessful: true }) throw HandleError(restResponse.Content!);
-
-        var resultJsonDocument = JsonDocument.Parse(restResponse.Content!);
-        var result = resultJsonDocument.Deserialize<VoteData>(JsonSerializerOptions)!;
-        return result;*/
-
         var requestUrl = $"{ipAddress}/votes";
-        var response = await HttpClient.GetAsync(requestUrl, cancellationToken ?? new CancellationToken());
-        var resultJson = await response.Content.ReadAsStringAsync();
-        if (response is not { IsSuccessStatusCode: true })
-        {
-            throw HandleError(resultJson);
-        }
-        
-        var resultJsonDocument = JsonDocument.Parse(resultJson);
-        var result = resultJsonDocument.Deserialize<VoteData>(JsonSerializerOptions)!;
-        return result;
+        return await GetAsync<VoteData>(requestUrl, cancellationToken ?? new CancellationToken());
     }
 
     /// <summary>
@@ -133,25 +87,9 @@ public class AddressIpEndpoint(string apiKey) : BaseEndpoint(apiKey, "ip_address
     /// <exception cref="NotFoundException">Given IP address not found.</exception>
     public async Task AddVote(string ipAddress, VerdictType verdict, CancellationToken? cancellationToken)
     {
-        /*var newVote = new AddVote(verdict);
-
-        var requestUrl = $"/{ipAddress}/votes";
-        var serializedJson = JsonSerializer.Serialize(newVote, JsonSerializerOptions);
-        var request = new RestRequest(requestUrl)
-            .AddJsonBody(serializedJson);
-
-        var restResponse = await PostResponse(request, cancellationToken);
-        if (restResponse is { IsSuccessful: false }) throw HandleError(restResponse.Content!);*/
-        
-        
         var newVote = new AddVote(verdict);
         var requestUrl = $"/{ipAddress}/votes";
         
-        var response = await HttpClient.PostAsJsonAsync(requestUrl, newVote, cancellationToken ?? new CancellationToken());
-        var resultJson = await response.Content.ReadAsStringAsync();
-        if (response is not { IsSuccessStatusCode: true })
-        {
-            throw HandleError(resultJson);
-        }
+        await PostAsync(requestUrl, newVote, cancellationToken ?? new CancellationToken());
     }
 }

--- a/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
@@ -9,8 +9,8 @@ namespace VirusTotalCore.Endpoints;
 
 public class AddressIpEndpoint : BaseEndpoint
 {
-    public AddressIpEndpoint(string apiKey) : base(apiKey, "files/") { }
-    public AddressIpEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
+    public AddressIpEndpoint(string apiKey) : base(apiKey, "ip_addresses/") { }
+    public AddressIpEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "ip_addresses/") { }
     /// <summary>
     ///     Get report on given ip address
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/AddressIpEndpoint.cs
@@ -10,7 +10,7 @@ namespace VirusTotalCore.Endpoints;
 public class AddressIpEndpoint : BaseEndpoint
 {
     public AddressIpEndpoint(string apiKey) : base(apiKey, "ip_addresses") { }
-    public AddressIpEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "ip_addresses") { }
+    public AddressIpEndpoint(IHttpClientFactory customHttpClient, string apiKey) : base(customHttpClient, apiKey, "ip_addresses") { }
     /// <summary>
     ///     Get report on given ip address
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
@@ -9,8 +9,8 @@ namespace VirusTotalCore.Endpoints;
 /// <param name="apiKey">User's API key</param>
 public class CommentEndpoint : BaseEndpoint
 {
-    public CommentEndpoint(string apiKey) : base(apiKey, "comments/") { }
-    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "comments/") { }
+    public CommentEndpoint(string apiKey) : base(apiKey, "comments") { }
+    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "comments") { }
     /// <summary>
     /// This endpoint retrieves information about the latest comments added to VirusTotal.
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
@@ -9,8 +9,8 @@ namespace VirusTotalCore.Endpoints;
 /// <param name="apiKey">User's API key</param>
 public class CommentEndpoint : BaseEndpoint
 {
-    public CommentEndpoint(string apiKey) : base(apiKey, "files/") { }
-    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
+    public CommentEndpoint(string apiKey) : base(apiKey, "comments") { }
+    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "comments") { }
     /// <summary>
     /// This endpoint retrieves information about the latest comments added to VirusTotal.
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
@@ -1,8 +1,5 @@
-using System.Text.Json;
-using RestSharp;
 using VirusTotalCore.Models.Comments;
 using VirusTotalCore.Models.Comments.Vote;
-using VirusTotalCore.Models.Votes;
 
 namespace VirusTotalCore.Endpoints;
 
@@ -10,8 +7,10 @@ namespace VirusTotalCore.Endpoints;
 /// Get comments, delete own comments or add votes to comment.
 /// </summary>
 /// <param name="apiKey">User's API key</param>
-public class CommentEndpoint(string apiKey) : BaseEndpoint(apiKey, "comments/")
+public class CommentEndpoint : BaseEndpoint
 {
+    public CommentEndpoint(string apiKey) : base(apiKey, "files/") { }
+    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
     /// <summary>
     /// This endpoint retrieves information about the latest comments added to VirusTotal.
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
@@ -9,8 +9,8 @@ namespace VirusTotalCore.Endpoints;
 /// <param name="apiKey">User's API key</param>
 public class CommentEndpoint : BaseEndpoint
 {
-    public CommentEndpoint(string apiKey) : base(apiKey, "comments") { }
-    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "comments") { }
+    public CommentEndpoint(string apiKey) : base(apiKey, "comments/") { }
+    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "comments/") { }
     /// <summary>
     /// This endpoint retrieves information about the latest comments added to VirusTotal.
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
@@ -10,7 +10,7 @@ namespace VirusTotalCore.Endpoints;
 /// Get comments, delete own comments or add votes to comment.
 /// </summary>
 /// <param name="apiKey">User's API key</param>
-public class CommentEndpoint(string apiKey) : BaseEndpoint(apiKey, "/comments/")
+public class CommentEndpoint(string apiKey) : BaseEndpoint(apiKey, "comments/")
 {
     /// <summary>
     /// This endpoint retrieves information about the latest comments added to VirusTotal.

--- a/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/CommentEndpoint.cs
@@ -10,7 +10,7 @@ namespace VirusTotalCore.Endpoints;
 public class CommentEndpoint : BaseEndpoint
 {
     public CommentEndpoint(string apiKey) : base(apiKey, "comments") { }
-    public CommentEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "comments") { }
+    public CommentEndpoint(IHttpClientFactory customHttpClient, string apiKey) : base(customHttpClient, apiKey, "comments") { }
     /// <summary>
     /// This endpoint retrieves information about the latest comments added to VirusTotal.
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
@@ -69,17 +69,7 @@ public class DomainsEndpoint(string apiKey) : BaseEndpoint(apiKey, "/domains")
     /// <exception cref="Exception"></exception>
     public async Task<Comment> AddComment(string domain, string comment, CancellationToken? cancellationToken)
     {
-        var newComment = new AddComment
-        {
-            Data = new AddData<AddCommentAttribute>
-            {
-                Type = "comment",
-                Attributes = new AddCommentAttribute
-                {
-                    Text = comment
-                }
-            }
-        };
+        var newComment = new AddComment(comment);
         var requestUrl = $"/{domain}/comments";
 
         var serializedJson = JsonSerializer.Serialize(newComment, JsonSerializerOptions);
@@ -129,17 +119,7 @@ public class DomainsEndpoint(string apiKey) : BaseEndpoint(apiKey, "/domains")
     /// <exception cref="Exception"></exception>
     public async Task AddVote(string domain, VerdictType verdict, CancellationToken? cancellationToken)
     {
-        var newVote = new AddVote
-        {
-            Data = new AddData<AddVoteAttribute>
-            {
-                Type = "vote",
-                Attributes = new AddVoteAttribute
-                {
-                    Verdict = verdict.ToString().ToLower()
-                }
-            }
-        };
+        var newVote = new AddVote(verdict);
 
         var requestUrl = $"/{domain}/votes";
         var serializedJson = JsonSerializer.Serialize(newVote, JsonSerializerOptions);

--- a/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
@@ -8,8 +8,8 @@ namespace VirusTotalCore.Endpoints;
 
 public class DomainsEndpoint : BaseEndpoint
 {
-    public DomainsEndpoint(string apiKey) : base(apiKey, "files/") { }
-    public DomainsEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
+    public DomainsEndpoint(string apiKey) : base(apiKey, "domains/") { }
+    public DomainsEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "domains/") { }
     /// <summary>
     /// Get report about specific domain
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
@@ -1,16 +1,15 @@
-using System.Text.Json;
-using RestSharp;
 using VirusTotalCore.Enums;
 using VirusTotalCore.Models.Analysis;
 using VirusTotalCore.Models.Analysis.Domains;
 using VirusTotalCore.Models.Comments;
-using VirusTotalCore.Models.Shared;
 using VirusTotalCore.Models.Votes;
 
 namespace VirusTotalCore.Endpoints;
 
-public class DomainsEndpoint(string apiKey) : BaseEndpoint(apiKey, "domains/")
+public class DomainsEndpoint : BaseEndpoint
 {
+    public DomainsEndpoint(string apiKey) : base(apiKey, "files/") { }
+    public DomainsEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
     /// <summary>
     /// Get report about specific domain
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
@@ -8,8 +8,8 @@ namespace VirusTotalCore.Endpoints;
 
 public class DomainsEndpoint : BaseEndpoint
 {
-    public DomainsEndpoint(string apiKey) : base(apiKey, "domains/") { }
-    public DomainsEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "domains/") { }
+    public DomainsEndpoint(string apiKey) : base(apiKey, "domains") { }
+    public DomainsEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "domains") { }
     /// <summary>
     /// Get report about specific domain
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/DomainsEndpoint.cs
@@ -9,7 +9,7 @@ namespace VirusTotalCore.Endpoints;
 public class DomainsEndpoint : BaseEndpoint
 {
     public DomainsEndpoint(string apiKey) : base(apiKey, "domains") { }
-    public DomainsEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "domains") { }
+    public DomainsEndpoint(IHttpClientFactory customHttpClient, string apiKey) : base(customHttpClient, apiKey, "domains") { }
     /// <summary>
     /// Get report about specific domain
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/FilesEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/FilesEndpoint.cs
@@ -1,6 +1,5 @@
 ﻿using System.Security.Cryptography;
 using System.Text.Json;
-using RestSharp;
 using VirusTotalCore.Models.Analysis;
 using VirusTotalCore.Models.Analysis.File;
 
@@ -10,8 +9,10 @@ namespace VirusTotalCore.Endpoints;
 /// Send files for scanning and get report about them.
 /// </summary>
 /// <param name="apiKey">User's API key.</param>
-public class FilesEndpoint(string apiKey) : BaseEndpoint(apiKey, "/files")
+public class FilesEndpoint : BaseEndpoint
 {
+    public FilesEndpoint(string apiKey) : base(apiKey, "files/") { }
+    public FilesEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
     /// <summary>
     /// Size of file is allowed to post without requesting an URL for it (32 MB in bytes).
     /// </summary>
@@ -31,7 +32,7 @@ public class FilesEndpoint(string apiKey) : BaseEndpoint(apiKey, "/files")
         CancellationToken? cancellationToken)
     {
         cancellationToken ??= new CancellationToken();
-        var url = Client.Options.BaseUrl!.ToString();
+        var url = HttpClient.BaseAddress!.ToString().TrimEnd('/');
 
         if (File.Exists(pathToFile))
         {
@@ -40,6 +41,8 @@ public class FilesEndpoint(string apiKey) : BaseEndpoint(apiKey, "/files")
 
             if (fileSizeBytes > MaxSmallSizeBytes)
             {
+                //https://github.com/aio-libs/aiohttp/issues/4678
+                //Exception: Malformed multipart body.
                 url = await GetUrlForPost(cancellationToken);
             }
         }
@@ -48,21 +51,30 @@ public class FilesEndpoint(string apiKey) : BaseEndpoint(apiKey, "/files")
             throw new FileNotFoundException($"Unable to find the specified file. Path is {pathToFile}");
         }
 
-        var localClient = new RestClient(url);
-        var request = new RestRequest("")
-            .AddHeader("x-apikey", ApiKey)
-            .AddFile("file", pathToFile, "multipart/form-data");
+        await using var sendStream = File.OpenRead(pathToFile);
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
+        using var content = new MultipartFormDataContent();
 
-        if (password is not null) request.AddJsonBody(JsonSerializer.Serialize(password));
-
-        var restResponse = await localClient.ExecutePostAsync(request, cancellationToken.Value);
-        if (restResponse is not { IsSuccessful: true }) throw HandleError(restResponse.Content!);
-
+        content.Add(new StreamContent(sendStream), "file", Path.GetFileName(sendStream.Name));
+        if (password is not null)
+        {
+            content.Add(new StringContent(password), "password");    
+        }
+        
+        requestMessage.Content = content;
+    
+        using var response = await HttpClient.SendAsync(requestMessage);
+        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken.Value);
+        if (response is not { IsSuccessStatusCode: true })
+        {
+            throw HandleError(resultJson);
+        }
+        
         var sha256 = SHA256.Create();
         byte[] hashBytes;
-        await using (var stream = File.OpenRead(pathToFile))
+        await using (var localStream = File.OpenRead(pathToFile))
         {
-            hashBytes = await sha256.ComputeHashAsync(stream);
+            hashBytes = await sha256.ComputeHashAsync(localStream);
         }
         
         return System.Text.Encoding.Default.GetString(hashBytes);
@@ -76,13 +88,21 @@ public class FilesEndpoint(string apiKey) : BaseEndpoint(apiKey, "/files")
     /// <exception cref="Exception"></exception>
     private async Task<string> GetUrlForPost(CancellationToken? cancellationToken)
     {
-        var request = new RestRequest("/upload_url");
+        cancellationToken ??= new CancellationToken();
+        var requestUrl = "upload_url";
+        const string rootPropertyName = "data";
+        
+        using var response = await HttpClient.GetAsync(requestUrl, cancellationToken.Value);
+        var resultJson = await response.Content.ReadAsStringAsync(cancellationToken.Value);
+        if (response is not { IsSuccessStatusCode: true })
+        {
+            throw HandleError(resultJson);
+        }
+        
+        var resultJsonDocument = JsonDocument.Parse(resultJson);
+        var result = resultJsonDocument.RootElement.GetProperty(rootPropertyName).GetString()!;
 
-        var restResponse = await GetResponse(request, cancellationToken);
-
-        if (restResponse is not { IsSuccessful: true }) throw HandleError(restResponse.Content!);
-        var resultJsonDocument = JsonDocument.Parse(restResponse.Content!);
-        return resultJsonDocument.RootElement.GetProperty("data").GetString()!;
+        return result;
     }
 
     /// <summary>
@@ -94,14 +114,7 @@ public class FilesEndpoint(string apiKey) : BaseEndpoint(apiKey, "/files")
     /// <exception cref="Exception"></exception>
     public async Task<AnalysisReport<FileReportAttributes>> GetReport(string fileHash, CancellationToken? cancellationToken)
     {
-        var request = new RestRequest($"/{fileHash}");
-
-        var restResponse = await GetResponse(request, cancellationToken);
-
-        if (restResponse is not { IsSuccessful: true }) throw HandleError(restResponse.Content!);
-        var resultJsonDocument = JsonDocument.Parse(restResponse.Content!);
-        var reportResult = resultJsonDocument.RootElement.GetProperty("data")
-            .Deserialize<AnalysisReport<FileReportAttributes>>(JsonSerializerOptions)!;
-        return reportResult;
+        const string rootPropertyName = "data";
+        return await GetAsync<AnalysisReport<FileReportAttributes>>(fileHash, rootPropertyName, cancellationToken ?? new CancellationToken());
     }
 }

--- a/src/VirusTotalCore/Endpoints/FilesEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/FilesEndpoint.cs
@@ -11,8 +11,8 @@ namespace VirusTotalCore.Endpoints;
 /// <param name="apiKey">User's API key.</param>
 public class FilesEndpoint : BaseEndpoint
 {
-    public FilesEndpoint(string apiKey) : base(apiKey, "files/") { }
-    public FilesEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
+    public FilesEndpoint(string apiKey) : base(apiKey, "files") { }
+    public FilesEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files") { }
     /// <summary>
     /// Size of file is allowed to post without requesting an URL for it (32 MB in bytes).
     /// </summary>
@@ -32,7 +32,7 @@ public class FilesEndpoint : BaseEndpoint
         CancellationToken? cancellationToken)
     {
         cancellationToken ??= new CancellationToken();
-        var url = HttpClient.BaseAddress!.ToString().TrimEnd('/');
+        var url = HttpClient.BaseAddress! + CurrentEndpointName;
 
         if (File.Exists(pathToFile))
         {

--- a/src/VirusTotalCore/Endpoints/FilesEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/FilesEndpoint.cs
@@ -12,7 +12,7 @@ namespace VirusTotalCore.Endpoints;
 public class FilesEndpoint : BaseEndpoint
 {
     public FilesEndpoint(string apiKey) : base(apiKey, "files") { }
-    public FilesEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files") { }
+    public FilesEndpoint(IHttpClientFactory customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files") { }
     /// <summary>
     /// Size of file is allowed to post without requesting an URL for it (32 MB in bytes).
     /// </summary>

--- a/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
@@ -1,10 +1,7 @@
-using System.Text.Json;
-using RestSharp;
 using VirusTotalCore.Enums;
 using VirusTotalCore.Models.Analysis;
 using VirusTotalCore.Models.Analysis.URL;
 using VirusTotalCore.Models.Comments;
-using VirusTotalCore.Models.Shared;
 using VirusTotalCore.Models.Votes;
 
 namespace VirusTotalCore.Endpoints;
@@ -13,8 +10,10 @@ namespace VirusTotalCore.Endpoints;
 /// Analyse URLs, get reports, comments and votes about it and owns.
 /// </summary>
 /// <param name="apiKey">User's API key.</param>
-public class UrlEndpoint(string apiKey) : BaseEndpoint(apiKey, "urls/")
+public class UrlEndpoint : BaseEndpoint
 {
+    public UrlEndpoint(string apiKey) : base(apiKey, "files/") { }
+    public UrlEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
     // TODO: Rewrite it
     /// <summary>
     /// Request to scan URL. 

--- a/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
@@ -12,8 +12,8 @@ namespace VirusTotalCore.Endpoints;
 /// <param name="apiKey">User's API key.</param>
 public class UrlEndpoint : BaseEndpoint
 {
-    public UrlEndpoint(string apiKey) : base(apiKey, "urls/") { }
-    public UrlEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "urls/") { }
+    public UrlEndpoint(string apiKey) : base(apiKey, "urls") { }
+    public UrlEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "urls") { }
     // TODO: Rewrite it
     /// <summary>
     /// Request to scan URL. 

--- a/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
@@ -12,8 +12,8 @@ namespace VirusTotalCore.Endpoints;
 /// <param name="apiKey">User's API key.</param>
 public class UrlEndpoint : BaseEndpoint
 {
-    public UrlEndpoint(string apiKey) : base(apiKey, "files/") { }
-    public UrlEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "files/") { }
+    public UrlEndpoint(string apiKey) : base(apiKey, "urls/") { }
+    public UrlEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "urls/") { }
     // TODO: Rewrite it
     /// <summary>
     /// Request to scan URL. 

--- a/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
@@ -93,17 +93,7 @@ public class UrlEndpoint(string apiKey) : BaseEndpoint(apiKey, "/urls")
     /// <exception cref="Exception"></exception>
     public async Task<Comment> AddComment(string id, string comment, CancellationToken? cancellationToken)
     {
-        var newComment = new AddComment
-        {
-            Data = new AddData<AddCommentAttribute>
-            {
-                Type = "comment",
-                Attributes = new AddCommentAttribute
-                {
-                    Text = comment
-                }
-            }
-        };
+        var newComment = new AddComment(comment);
         
         var serializedJson = JsonSerializer.Serialize(newComment, JsonSerializerOptions);
         var request = new RestRequest($"/{id}/comments")
@@ -148,17 +138,7 @@ public class UrlEndpoint(string apiKey) : BaseEndpoint(apiKey, "/urls")
     /// <exception cref="Exception"></exception>
     public async Task AddVote(string id, VerdictType verdict, CancellationToken? cancellationToken)
     {
-        var newVote = new AddVote
-        {
-            Data = new AddData<AddVoteAttribute>
-            {
-                Type = "vote",
-                Attributes = new AddVoteAttribute
-                {
-                    Verdict = verdict.ToString().ToLower()
-                }
-            }
-        };
+        var newVote = new AddVote(verdict);
 
         var requestUrl = $"/{id}/votes";
         var serializedJson = JsonSerializer.Serialize(newVote, JsonSerializerOptions);

--- a/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
+++ b/src/VirusTotalCore/Endpoints/UrlEndpoint.cs
@@ -13,7 +13,7 @@ namespace VirusTotalCore.Endpoints;
 public class UrlEndpoint : BaseEndpoint
 {
     public UrlEndpoint(string apiKey) : base(apiKey, "urls") { }
-    public UrlEndpoint(HttpClient customHttpClient, string apiKey) : base(customHttpClient, apiKey, "urls") { }
+    public UrlEndpoint(IHttpClientFactory customHttpClient, string apiKey) : base(customHttpClient, apiKey, "urls") { }
     // TODO: Rewrite it
     /// <summary>
     /// Request to scan URL. 

--- a/src/VirusTotalCore/Models/Analysis/File/FileReportAttributes.cs
+++ b/src/VirusTotalCore/Models/Analysis/File/FileReportAttributes.cs
@@ -18,7 +18,7 @@ public class FileReportAttributes
     public long TimesSubmitted { get; set; }
     public required Votes TotalVotes { get; set; }
     public long Size { get; set; }
-    public required string TypeExtension { get; set; }
+    public string? TypeExtension { get; set; }
     public long LastSubmissionDate { get; set; }
     public required Dictionary<string, EngineAnalysisResult> LastAnalysisResults { get; set; }
     public required string Sha256 { get; set; }

--- a/src/VirusTotalCore/Models/Comments/AddComment.cs
+++ b/src/VirusTotalCore/Models/Comments/AddComment.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using VirusTotalCore.Models.Shared;
 
 namespace VirusTotalCore.Models.Comments;
@@ -5,4 +6,17 @@ namespace VirusTotalCore.Models.Comments;
 public class AddComment
 {
     public required AddData<AddCommentAttribute> Data { get; set; }
+
+    [SetsRequiredMembers]
+    public AddComment(string comment)
+    {
+        Data = new AddData<AddCommentAttribute>
+        {
+            Type = "comment",
+            Attributes = new AddCommentAttribute
+            {
+                Text = comment
+            }
+        };
+    }
 }

--- a/src/VirusTotalCore/Models/Votes/AddVote.cs
+++ b/src/VirusTotalCore/Models/Votes/AddVote.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using VirusTotalCore.Enums;
 using VirusTotalCore.Models.Shared;
 
 namespace VirusTotalCore.Models.Votes;
@@ -5,4 +7,18 @@ namespace VirusTotalCore.Models.Votes;
 public class AddVote
 {
     public required AddData<AddVoteAttribute> Data { get; set; }
+
+    [SetsRequiredMembers]
+    public AddVote(VerdictType verdict)
+    {
+        Data = new AddData<AddVoteAttribute>
+        {
+            Type = "vote",
+            Attributes = new AddVoteAttribute
+            {
+                Verdict = verdict.ToString().ToLower()
+            }
+        };
+        
+    }
 }

--- a/src/VirusTotalCore/VirusTotalCore.csproj
+++ b/src/VirusTotalCore/VirusTotalCore.csproj
@@ -14,8 +14,4 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="RestSharp" Version="110.2.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/VirusTotalCore/VirusTotalCore.csproj
+++ b/src/VirusTotalCore/VirusTotalCore.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>1.1.0</Version>
@@ -12,6 +11,12 @@
     <PackageLicenseUrl>https://github.com/hunterlan/VirusTotalCore/blob/main/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/hunterlan/VirusTotalCore</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>12</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/tests/VirusTotalCore.Tests/CommentTest.cs
+++ b/tests/VirusTotalCore.Tests/CommentTest.cs
@@ -34,11 +34,17 @@ public class CommentTest
     {
         var token = new CancellationToken();
         var exampleCommentData = await CreateComment(token);
-        var realCommentData = await _endpoint.Get(exampleCommentData.Id, token);
-        Assert.True(string.Equals(exampleCommentData.Id, realCommentData.Id) 
-                    && string.Equals(exampleCommentData.Attributes.Text, realCommentData.Attributes.Text)
-                    && exampleCommentData.Attributes.Date == realCommentData.Attributes.Date);
-        await _endpoint.Delete(exampleCommentData.Id, token);
+        try
+        {
+            var realCommentData = await _endpoint.Get(exampleCommentData.Id, token);
+            Assert.True(string.Equals(exampleCommentData.Id, realCommentData.Id) 
+                        && string.Equals(exampleCommentData.Attributes.Text, realCommentData.Attributes.Text)
+                        && exampleCommentData.Attributes.Date == realCommentData.Attributes.Date);
+        }
+        finally
+        {
+            await _endpoint.Delete(exampleCommentData.Id, token);   
+        }
     }
 
     [Fact]
@@ -46,10 +52,16 @@ public class CommentTest
     {
         var token = new CancellationToken();
         var commentData = await CreateComment(token);
-        await _endpoint.AddVote(commentData.Id, CommentVerdict.Positive, token);
-        var realCommentData = await _endpoint.Get(commentData.Id, token);
-        Assert.True(realCommentData.Attributes.Votes.Positive is 1);
-        await _endpoint.Delete(commentData.Id, token);
+        try
+        {
+            await _endpoint.AddVote(commentData.Id, CommentVerdict.Positive, token);
+            var realCommentData = await _endpoint.Get(commentData.Id, token);
+            Assert.True(realCommentData.Attributes.Votes.Positive is 1);
+        }
+        finally
+        {
+            await _endpoint.Delete(commentData.Id, token);   
+        }
     }
 
     private async Task<Comment> CreateComment(CancellationToken cancellationToken)

--- a/tests/VirusTotalCore.Tests/DomainTest.cs
+++ b/tests/VirusTotalCore.Tests/DomainTest.cs
@@ -43,8 +43,14 @@ public class DomainTest
         var commentEndpoint = new CommentEndpoint(ApiKey);
         const string comment = "It's google and it's safe";
         var commentResult = await _endpoint.AddComment(GoogleDomain, comment, cancellationToken);
-        Assert.True(string.Equals(commentResult.Attributes.Text, comment));
-        await commentEndpoint.Delete(commentResult.Id, cancellationToken);
+        try
+        {
+            Assert.True(string.Equals(commentResult.Attributes.Text, comment));
+        }
+        finally
+        {
+            await commentEndpoint.Delete(commentResult.Id, cancellationToken);   
+        }
     }
     
     [Fact]

--- a/tests/VirusTotalCore.Tests/FilesTest.cs
+++ b/tests/VirusTotalCore.Tests/FilesTest.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Configuration;
-using RestSharp;
 using VirusTotalCore.Endpoints;
 using Xunit.Abstractions;
 

--- a/tests/VirusTotalCore.Tests/IpAddressTest.cs
+++ b/tests/VirusTotalCore.Tests/IpAddressTest.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using VirusTotalCore.Endpoints;
 using VirusTotalCore.Exceptions;
+using VirusTotalCore.Models.Comments;
 
 namespace VirusTotalCore.Tests;
 
@@ -66,16 +67,25 @@ public class IpAddressTest
     public async Task AddCommentTest()
     {
         var comment = "This is test comment for VirusTotalCore library";
+        Comment? publishedComment = null;
         var cancellationToken = new CancellationToken();
         var commentEndpoint = new CommentEndpoint(ApiKey);
         
         await _endpoint.AddComment(IpAddress, comment, cancellationToken);
-        var commentData = await _endpoint.GetComments(IpAddress, null, cancellationToken);
-        var publishedComment = commentData.Comments.First();
-        Assert.Equal(comment, publishedComment.Attributes.Text);
-        
-        var commentId = publishedComment.Id;
-        await commentEndpoint.Delete(commentId, cancellationToken);
+        try
+        {
+            var commentData = await _endpoint.GetComments(IpAddress, null, cancellationToken); 
+            publishedComment = commentData.Comments.First();
+            Assert.Equal(comment, publishedComment.Attributes.Text);
+        }
+        finally
+        {
+            if (publishedComment is not null)
+            {
+                var commentId = publishedComment.Id;
+                await commentEndpoint.Delete(commentId, cancellationToken);      
+            }
+        }
     }
 
     [Fact]

--- a/tests/VirusTotalCore.Tests/VirusTotalCore.Tests.csproj
+++ b/tests/VirusTotalCore.Tests/VirusTotalCore.Tests.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <OutputType>Library</OutputType>
+        <LangVersion>12</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes #27 

This pull request remove dependency on RestSharp and allows to send to endpoint constructor own HttpClient. However, x-apikey and baseaddress anyway will be set up in constructor.