### PR TITLE
refactor: introduce base virus total exception (#43)

### DIFF
--- a/src/VirusTotalCore.Common/Exceptions/AlreadyExistsException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/AlreadyExistsException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class AlreadyExistsException(string message) : Exception(message);
+public class AlreadyExistsException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/AuthenticationRequiredException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/AuthenticationRequiredException.cs
@@ -3,4 +3,4 @@ namespace VirusTotalCore.Common.Exceptions;
 /// Exception for AuthenticationRequiredException response: "ApiKey is missing"
 /// </summary>
 /// <param name="message">Error message</param>
-public class AuthenticationRequiredException(string message) : Exception(message);
+public class AuthenticationRequiredException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/BadRequestException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/BadRequestException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class BadRequestException(string message) : Exception(message);
+public class BadRequestException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/DeadlineExceededException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/DeadlineExceededException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class DeadlineExceededException(string message) : Exception(message);
+public class DeadlineExceededException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/FailedDependencyException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/FailedDependencyException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class FailedDependencyException(string message) : Exception(message);
+public class FailedDependencyException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/ForbiddenException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/ForbiddenException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class ForbiddenException(string message) : Exception(message);
+public class ForbiddenException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/InvalidArgumentException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/InvalidArgumentException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class InvalidArgumentException(string message) : Exception(message);
+public class InvalidArgumentException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/NotAvailableYetException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/NotAvailableYetException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class NotAvailableYetException(string message) : Exception(message);
+public class NotAvailableYetException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/NotFoundException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/NotFoundException.cs
@@ -4,4 +4,4 @@ namespace VirusTotalCore.Common.Exceptions;
 /// Exception for NotFoundError response: "The requested resource was not found."
 /// </summary>
 /// <param name="message">Error message</param>
-public class NotFoundException(string message) : Exception(message);
+public class NotFoundException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/QuotaExceededException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/QuotaExceededException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class QuotaExceededException(string message) : Exception(message);
+public class QuotaExceededException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/TooManyRequestsException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/TooManyRequestsException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class TooManyRequestsException(string message) : Exception(message);
+public class TooManyRequestsException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/TransientException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/TransientException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class TransientException(string message) : Exception(message);
+public class TransientException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/UnselectiveContentQueryException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/UnselectiveContentQueryException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class UnselectiveContentQueryException(string message) : Exception(message);
+public class UnselectiveContentQueryException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/UnsupportedContentQueryException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/UnsupportedContentQueryException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class UnsupportedContentQueryException(string message) : Exception(message);
+public class UnsupportedContentQueryException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/UserNotActiveException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/UserNotActiveException.cs
@@ -1,3 +1,3 @@
 namespace VirusTotalCore.Common.Exceptions;
 
-public class UserNotActiveException(string message) : Exception(message);
+public class UserNotActiveException(string message) : VirusTotalException(message);

--- a/src/VirusTotalCore.Common/Exceptions/VirusTotalException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/VirusTotalException.cs
@@ -1,0 +1,7 @@
+namespace VirusTotalCore.Common.Exceptions;
+
+/// <summary>
+/// Base class for all VirusTotal-specific exceptions.
+/// </summary>
+/// <param name="message">Error message</param>
+public abstract class VirusTotalException(string message) : Exception(message);

--- a/src/VirusTotalCore.Common/Exceptions/WrongCredentialsException.cs
+++ b/src/VirusTotalCore.Common/Exceptions/WrongCredentialsException.cs
@@ -3,4 +3,4 @@ namespace VirusTotalCore.Common.Exceptions;
 /// Exception for WrongCredentialsException response: "Wrong API key"
 /// </summary>
 /// <param name="message">Error message</param>
-public class WrongCredentialsException(string message) : Exception(message);
+public class WrongCredentialsException(string message) : VirusTotalException(message);


### PR DESCRIPTION
New base VirusTotal exception is used for other VirusTotal custom exceptions and can be used for general interception if caller don't know or want catch specific exceptions.

Closes #43